### PR TITLE
Patch RooArgSet to fix text2workspace.py/ShapeBuilder

### DIFF
--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -2,6 +2,14 @@ from sys import stdout, stderr
 import os.path
 import ROOT
 
+RooArgSet_add_original = ROOT.RooArgSet.add
+def RooArgSet_add_patched(self, obj, *args, **kwargs):
+    if isinstance(obj, ROOT.RooAbsCollection):
+        return ROOT.RooAbsCollection.add(self, obj, *args, **kwargs)
+    else:
+        return RooArgSet_add_original(self, obj, *args, **kwargs)
+ROOT.RooArgSet.add = RooArgSet_add_patched
+
 from HiggsAnalysis.CombinedLimit.ModelTools import ModelBuilder
 
 class ShapeBuilder(ModelBuilder):


### PR DESCRIPTION
This PR addresses issue #353 which prevents text2workspace.py/ShapeBuilder to run using ROOT > 6.06/00.

This simple patch adds the missing signature for `RooArgSet.add(RooArgCollection)` that is required for

```python
self.out.obs = ROOT.RooArgSet()
self.out.obs.add(self.out.binVars)
```

in [`ShapeBuilder.doObservables`](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/29d06a04613355705d19cf8ad1892a2e71af27eb/python/ShapeTools.py#L32-L33) to work.